### PR TITLE
NOJIRA: Fixing an issue related to uncleared timeouts

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1055,6 +1055,11 @@ gpii.app.displayWaitDialog = function (that) {
  * @param that {Component} the gpii.app instance
  */
 gpii.app.dismissWaitDialog = function (that) {
+    if (that.dismissWaitTimeout) {
+        clearTimeout(that.dismissWaitTimeout);
+        that.dismissWaitTimeout = null;
+    }
+
     // ensure we have displayed for a minimum amount of `dialogMinDisplayTime` secs to avoid confusing flickering
     var remainingDisplayTime = (that.model.dialogStartTime + that.model.dialogMinDisplayTime) - Date.now();
 


### PR DESCRIPTION
Running `npm test`, logs that all tests have succeeded, but the process fails with exception.