### PR TITLE
NOJIRA: Fix hanging of electron tests

### DIFF
--- a/src/main/app.js
+++ b/src/main/app.js
@@ -40,6 +40,8 @@ gpii.app.electronAppListener = function () {
     gpii.app.appReady.resolve(true);
 };
 require("electron").app.on("ready", gpii.app.electronAppListener);
+// Override default behaviour - don't exit process once all windows are closed
+require("electron").app.on("window-all-closed", fluid.identity);
 
 /*
  ** Component to manage the app.
@@ -165,6 +167,10 @@ fluid.defaults("gpii.app", {
         "{lifecycleManager}.events.onSessionStop": {
             listener: "gpii.app.handleSessionStop",
             args: ["{that}", "{arguments}.1.options.userToken"]
+        },
+
+        "onDestroy.beforeExit": {
+            listener: "{that}.keyOut"
         }
     },
     invokers: {

--- a/src/main/psp.js
+++ b/src/main/psp.js
@@ -67,6 +67,11 @@ fluid.defaults("gpii.app.psp", {
         "onCreate.initPSPWindowListeners": {
             listener: "gpii.app.psp.initPSPWindowListeners",
             args: ["{that}"]
+        },
+
+        "onDestroy.cleanupElectron": {
+            this: "{that}.pspWindow",
+            method: "destroy"
         }
     },
     invokers: {

--- a/src/main/tray.js
+++ b/src/main/tray.js
@@ -83,6 +83,12 @@ fluid.defaults("gpii.app.tray", {
             args: "{that}.model.tooltip"
         }
     },
+    listeners: {
+        "onDestroy.cleanupElectron": {
+            this: "{that}.tray",
+            method: "destroy"
+        }
+    },
     labels: {
         defaultTooltip: "(No one keyed in)"
     }

--- a/src/main/waitDialog.js
+++ b/src/main/waitDialog.js
@@ -59,7 +59,11 @@ fluid.defaults("gpii.app.dialog", {
         }
     },
     listeners: {
-        "onDestroy.clearTimers": "gpii.app.dialog.clearTimers({that})"
+        "onDestroy.clearTimers": "gpii.app.dialog.clearTimers({that})",
+        "onDestroy.cleanupElectron": {
+            this: "{that}.dialog",
+            method: "destroy"
+        }
     },
     invokers: {
         getWindowPosition: {

--- a/tests/IntegrationTestDefs.js
+++ b/tests/IntegrationTestDefs.js
@@ -302,7 +302,5 @@ gpii.tests.dev.testDefs = {
             "{that}.app.model.preferences"
         ],
         listener: "gpii.tests.dev.testActiveSetChanged"
-    }
-        // tooltip
-    ]
+    }]
 };

--- a/tests/IntegrationTests.js
+++ b/tests/IntegrationTests.js
@@ -49,7 +49,6 @@ gpii.tests.app.testDefToCaseHolder = function (configurationName, testDefIn) {
     // as well as the server
     // sequence.unshift.apply(sequence, kettle.test.startServerSequence);
     sequence.unshift.apply(sequence, gpii.tests.app.startSequence);
-    sequence.push.apply(sequence, kettle.test.stopServerSequence);
     testDef.modules = [{
         name: configurationName + " tests",
         tests: [{
@@ -91,6 +90,6 @@ gpii.tests.app.bootstrapServer([
      *  It appears to be a bug in the `node-jqunit` and should be uncommented
      *  once the problem is removed
      */
-//    fluid.copy(gpii.tests.app.testDefs),
+    fluid.copy(gpii.tests.app.testDefs),
     fluid.copy(gpii.tests.dev.testDefs)
 ]);


### PR DESCRIPTION
#### A problem related to this [issue](https://github.com/electron/electron/issues/8915).
Our current version of electron is `1.4.1`, in which a fix for this issue wasn't yet introduced. 
#### More detailed description:
 Electron overrides `process.exit` to map to `app.exit` - you can see this [here](https://github.com/electron/electron/blob/b5dec9990eb34a711c57a4f639b2c4c8de866d5f/lib/browser/init.js#L100). On the other hand, in `node-jqunit`, which we use for tests execution, you can see [here](https://github.com/fluid-project/node-jqunit/blob/master/lib/jqUnit-node.js#L192) that we are dependent on the same `app.exit` method trough `process.exit`.
Keeping created windows numbers low enough seems to be sufficient solution for this problem.
