### PR TITLE
[INITIAL VERSION] Moving the dialogManager to be a subcomponent of the app

### DIFF
--- a/src/main/app.js
+++ b/src/main/app.js
@@ -20,6 +20,7 @@ var machineInfo = require("node-machine-id");
 
 
 require("./factsManager.js");
+require("./dialogManager.js");
 require("./gpiiConnector.js");
 require("./menu.js");
 require("./psp.js");
@@ -84,6 +85,22 @@ fluid.defaults("gpii.app", {
             type: "gpii.app.surveyManager",
             createOnEvent: "onPrerequisitesReady",
             priority: "after:rulesEngine"
+        },
+        dialogManager: {
+            type: "gpii.app.dialogManager",
+            createOnEvent: "onPrerequisitesReady",
+            priority: "after:surveyManager",
+            options: {
+                model: {
+                    keyedInUserToken: "{app}.model.keyedInUserToken"
+                },
+                listeners: {
+                    "{surveyManager}.events.onSurveyRequired": {
+                        func: "{that}.show",
+                        args: ["survey", "{arguments}.0"] // the raw payload
+                    }
+                }
+            }
         },
         psp: {
             type: "gpii.app.psp",

--- a/src/main/dialogManager.js
+++ b/src/main/dialogManager.js
@@ -15,7 +15,7 @@ https://github.com/GPII/universal/blob/master/LICENSE.txt
 var fluid = require("infusion"),
     gpii = fluid.registerNamespace("gpii");
 
-require("./surveyDialog.js");
+require("./surveys/surveyDialog.js");
 
 /**
  * A component which provides means for showing, hiding and closing of dialogs

--- a/src/main/dialogManager.js
+++ b/src/main/dialogManager.js
@@ -28,6 +28,9 @@ require("./surveys/surveyDialog.js");
  * In order to show/hide/close a dialog, the IoCSS selector of the particular
  * component needs to be provided as an argument of the corresponding function.
  */
+// XXX: Currently only the survey dialog is managed by the dialogManager. As a
+// refactoring step, in the future the rest of the dialogs will be controlled by
+// this manager, as well.
 fluid.defaults("gpii.app.dialogManager", {
     gradeNames: ["fluid.modelComponent"],
     model: {

--- a/src/main/surveys/surveyManager.js
+++ b/src/main/surveys/surveyManager.js
@@ -17,12 +17,12 @@ var fluid = require("infusion");
 require("../utils.js");
 require("./surveyTriggerManager.js");
 require("./surveyConnector.js");
-require("./dialogManager.js");
-
-
 
 fluid.defaults("gpii.app.surveyManager", {
     gradeNames: ["fluid.component"],
+    events: {
+        onSurveyRequired: null
+    },
 
     components: {
         surveyConnector: {
@@ -32,14 +32,12 @@ fluid.defaults("gpii.app.surveyManager", {
                     machineId: "{app}.model.machineId",
                     userId: "{app}.model.keyedInUserToken"
                 },
+                events: {
+                    onSurveyRequired: "{surveyManager}.events.onSurveyRequired"
+                },
                 listeners: {
                     "{app}.events.onKeyedIn": {
                         func: "{that}.requestTriggers"
-                    },
-
-                    onSurveyRequired: {
-                        func: "{dialogManager}.show",
-                        args: ["survey", "{arguments}.0"] // the raw payload
                     },
 
                     onTriggerDataReceived: {
@@ -61,15 +59,6 @@ fluid.defaults("gpii.app.surveyManager", {
                 },
                 components: {
                     rulesEngine: "{rulesEngine}"
-                }
-            }
-        },
-
-        dialogManager: {
-            type: "gpii.app.dialogManager",
-            options: {
-                model: {
-                    keyedInUserToken: "{app}.model.keyedInUserToken"
                 }
             }
         }

--- a/tests/DialogManagerTestDefs.js
+++ b/tests/DialogManagerTestDefs.js
@@ -103,44 +103,43 @@ gpii.tests.dialogManager.testDefs = {
         }
     },
     sequence: [{
-        event: "{that gpii.app.surveyManager}.events.onCreate",
-        listener: "gpii.tests.dialogManager.testManagerWithNoKeyedInUser",
-        args: ["{that}.app.surveyManager.dialogManager"]
+        event: "{that gpii.app.dialogManager}.events.onCreate",
+        listener: "gpii.tests.dialogManager.testManagerWithNoKeyedInUser"
     }, {
         func: "{that}.app.keyIn",
         args: ["snapset_1a"]
     }, {
-        changeEvent: "{that}.app.surveyManager.dialogManager.applier.modelChanged",
+        changeEvent: "{that}.app.dialogManager.applier.modelChanged",
         path: "keyedInUserToken",
         listener: "gpii.tests.dialogManager.testManagerAfterKeyIn",
-        args: ["{that}.app.surveyManager.dialogManager", "snapset_1a"]
+        args: ["{that}.app.dialogManager", "snapset_1a"]
     }, {
-        func: "{that}.app.surveyManager.dialogManager.show",
+        func: "{that}.app.dialogManager.show",
         args: ["survey", surveyDialogFixture]
     }, {
         event: "{that gpii.app.surveyDialog}.events.onSurveyCreated",
         listener: "gpii.tests.dialogManager.testSurveyDialogShown",
-        args: ["{that}.app.surveyManager.dialogManager", surveyDialogFixture]
+        args: ["{that}.app.dialogManager", surveyDialogFixture]
     }, { // Test hiding of a dialog via the manager
-        func: "{that}.app.surveyManager.dialogManager.hide",
+        func: "{that}.app.dialogManager.hide",
         args: ["survey"]
     }, {
         func: "gpii.tests.dialogManager.testSurveyDialogHidden",
-        args: ["{that}.app.surveyManager.dialogManager"]
+        args: ["{that}.app.dialogManager"]
     }, {
-        func: "{that}.app.surveyManager.dialogManager.show",
+        func: "{that}.app.dialogManager.show",
         args: ["survey", surveyDialogFixture]
     }, {
         event: "{that gpii.app.surveyDialog}.events.onSurveyCreated",
         listener: "fluid.identity"
     }, { // Test closing of a dialog via the manager
-        func: "{that}.app.surveyManager.dialogManager.close",
+        func: "{that}.app.dialogManager.close",
         args: ["survey"]
     }, {
         func: "gpii.tests.dialogManager.testSurveyDialogClosed",
-        args: ["{that}.app.surveyManager.dialogManager"]
+        args: ["{that}.app.dialogManager"]
     }, {
-        func: "{that}.app.surveyManager.dialogManager.show",
+        func: "{that}.app.dialogManager.show",
         args: ["survey", surveyDialogFixture]
     }, {
         event: "{that gpii.app.surveyDialog}.events.onSurveyCreated",
@@ -148,10 +147,10 @@ gpii.tests.dialogManager.testDefs = {
     }, {
         func: "{that}.app.keyOut"
     }, { // Test that the survey dialog is closed when the user keys out
-        changeEvent: "{that}.app.surveyManager.dialogManager.applier.modelChanged",
+        changeEvent: "{that}.app.dialogManager.applier.modelChanged",
         path: "keyedInUserToken",
         listener: "gpii.tests.dialogManager.testManagerWithNoKeyedInUser",
-        args: ["{that}.app.surveyManager.dialogManager"]
+        args: ["{that}.app.dialogManager"]
     }, { // Close the mock survey server gracefully
         func: "{that}.app.surveyManager.surveyServer.close"
     }, { // Wait for the mock survey server until it has closed itself completely

--- a/tests/SurveyServerMock.js
+++ b/tests/SurveyServerMock.js
@@ -24,7 +24,7 @@ fluid.registerNamespace("gpii.tests.mocks");
 fluid.defaults("gpii.tests.mocks.surveyServer", {
     gradeNames: "fluid.component",
     config: {
-        port: 3334
+        port: null // passed by the wrapper
     },
     members: {
         server: {
@@ -98,7 +98,7 @@ gpii.tests.mocks.surveyServer.close = function (that, server) {
 fluid.defaults("gpii.tests.mocks.surveyServerWrapper", {
     gradeNames: "fluid.component",
     config: {
-        port: 3334
+        port: 33345
     },
     components: {
         surveyServer: {


### PR DESCRIPTION
Extract all dialogs to the `dialogManager` component, so that all are in a single place.