### PR TITLE
GPII-3193: To work with the universal code that deals with "noUser" keyin

### DIFF
--- a/src/main/app.js
+++ b/src/main/app.js
@@ -391,7 +391,7 @@ gpii.app.fireAppReady = function (fireFn) {
   * @param {String} token - The token to key in with.
   */
 gpii.app.keyIn = function (flowManager, token) {
-    request("http://localhost:8081/user/" + token + "/login", function (error, response, body) {
+    request("http://localhost:8081/user/" + token + "/proximityTriggered", function (error, response, body) {
 
         // Try is needed as the response body has two formats:
         //  - success message - simple string (like message key of the object)
@@ -420,7 +420,7 @@ gpii.app.keyIn = function (flowManager, token) {
   */
 gpii.app.keyOut = function (token) {
     var togo = fluid.promise();
-    request("http://localhost:8081/user/" + token + "/logout", function (error, response, body) {
+    request("http://localhost:8081/user/" + token + "/proximityTriggered", function (error, response, body) {
         //TODO Put in some error logging
         if (error) {
             togo.reject(error);
@@ -490,4 +490,3 @@ fluid.defaults("gpii.appWrapper", {
         }
     }
 });
-

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -129,6 +129,12 @@ fluid.defaults("gpii.app.menuInAppDev", {
             changePath: "{app}.model.theme",
             value: "{arguments}.0.theme"
         },
+        // Key-in using /proximityTriggered endpoint automatically takes care
+        // of the keyout of the preious key.
+        "onKeyIn.performKeyIn": {
+            listener: "{app}.keyIn",
+            args: ["{arguments}.0.token"], // token
+        },
         // onKeyIn event is fired when a new user keys in through the task tray.
         // This should result in:
         // 1. key out the old keyed in user token
@@ -136,14 +142,15 @@ fluid.defaults("gpii.app.menuInAppDev", {
         //   a) trigger GPII {lifecycleManager}.events.onSessionStart
         //   b) fire a model change to set the new model.keyedInUserToken
         //   c) update the menu
-        "onKeyIn.performKeyOut": {
-            listener: "{app}.keyOut"
-        },
-        "onKeyIn.performKeyIn": {
-            listener: "{app}.keyIn",
-            args: ["{arguments}.0.token"], // token
-            priority: "after:performKeyOut"
-        },
+        // "onKeyIn.performKeyOut": {
+        //     listener: "{app}.keyOut",
+        //     args: ["{that}.model.keyedInUserToken", true]
+        // },
+        // "onKeyIn.performKeyIn": {
+        //     listener: "{app}.keyIn",
+        //     args: ["{arguments}.0.token"], // token
+        //     priority: "after:performKeyOut"
+        // },
 
         // onExit
         "onExit.performExit": {


### PR DESCRIPTION
This pull request switches the keyin (/login) and keyout (/logout) actions to use [/proximityTriggered endpoint](https://github.com/GPII/universal/blob/master/documentation/FlowManager.md#user-logon-state-change-get-usergpiikeyproximitytriggered). The advantage of using /proximityTriggered endpoint is it will automatically key out the previous key (if there's one) before keying in the new key.

This change is to make it easier for [GPII-3193 universal pull request](https://github.com/GPII/universal/pull/637) to handle the "noUser" keyin in terms of handling async requests on keyin, keyout, keyin with noUser, keyout with noUser via one incoming request.

Once "noUser" keyin is properly implemented, this requirement will not be needed. But, it's still harmless (and better, in my opinion) to use /proximityTriggered endpoint for keyin and keyout.