### PR TITLE
Improved mega bundle grunt task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -20,8 +20,11 @@ module.exports = function (grunt) {
         },
         compileMessages: {
             defaults: {
+                messagesDirs: [
+                    "./messageBundles",
+                    "%gpii-user-errors/bundles"
+                ],
                 messageCompilerPath: "./messageBundlesCompiler.js",
-                messagesDirs: ["./messageBundles"],
                 resultFilePath: "./build/gpii-app-messageBundles.json"
             }
         }
@@ -34,10 +37,16 @@ module.exports = function (grunt) {
     grunt.registerTask("lint", "Perform all standard lint checks.", ["lint-all"]);
 
 
-    grunt.registerMultiTask("compileMessages", function () {
-        var compileMessageBundles = require(this.data.messageCompilerPath).compileMessageBundles;
+    /*
+     * Generate "Mega" messages bundle out of all supplied message bundles. Bundles
+     * are loaded from given directories.
+     */
+    grunt.registerMultiTask("compileMessages", "Generate i18n messages 'Mega' bundle", function () {
+        // Get all possible paths
+        require("gpii-universal");
 
-        var compiledMessageBundles = compileMessageBundles(this.data.messagesDirs, "en", {"json": JSON});
+        var compileMessageBundles = require(this.data.messageCompilerPath).compileMessageBundles;
+        var compiledMessageBundles = compileMessageBundles(this.data.messagesDirs, "en", {"json": JSON, "json5": require("json5")});
 
         grunt.file.write(this.data.resultFilePath, JSON.stringify(compiledMessageBundles, null, 4));
     });

--- a/messageBundlesCompiler.js
+++ b/messageBundlesCompiler.js
@@ -156,7 +156,8 @@ gpii.app.messageBundlesCompiler.collectFilesByType = function (dir, fileTypes) {
 };
 
 /**
- * Loads synchronously all message bundles from the passed directories.
+ * Loads synchronously all message bundles from the passed directories. Note that directories'
+ * paths may include gpii module references.
  * @param {String[]} bundlesDirs - The list of directrories' names containing message bundles.
  * @param {FileParsers} parsers - Available parsers for the bundle files. Bundles for the
  * provided file types will be used for collected.
@@ -165,9 +166,11 @@ gpii.app.messageBundlesCompiler.collectFilesByType = function (dir, fileTypes) {
 gpii.app.messageBundlesCompiler.loadMessageBundles = function (bundlesDirs, parsers) {
     var fileTypes = fluid.keys(parsers);
 
-    var bundleFiles = bundlesDirs.reduce(function (files, bundlesDir) {
-        return files.concat(gpii.app.messageBundlesCompiler.collectFilesByType(bundlesDir, fileTypes));
-    }, []);
+    var bundleFiles = bundlesDirs
+        .map(fluid.module.resolvePath)
+        .reduce(function (files, bundlesDir) {
+            return files.concat(gpii.app.messageBundlesCompiler.collectFilesByType(bundlesDir, fileTypes));
+        }, []);
 
     return bundleFiles.map(function (filePath) {
         var fileType = path.extname(filePath).slice(1),

--- a/src/main/dialogs/aboutDialog.js
+++ b/src/main/dialogs/aboutDialog.js
@@ -16,7 +16,7 @@
 
 var fluid = require("infusion");
 
-var app = require("electron").app;
+fluid.require("electron", require, "gpii.app.electron");
 
 require("./basic/dialog.js");
 
@@ -34,7 +34,7 @@ fluid.defaults("gpii.app.aboutDialog", {
     config: {
         params: {
             userListeners: ["USB", "NFC", "Fingerprint", "Webcam & Voice"],
-            version: { expander: { func: app.getVersion } }
+            version: { expander: { func: "gpii.app.electron.app.getVersion" } }
         },
         fileSuffixPath: "aboutDialog/index.html"
     },

--- a/src/main/dialogs/aboutDialog.js
+++ b/src/main/dialogs/aboutDialog.js
@@ -16,10 +16,9 @@
 
 var fluid = require("infusion");
 
-fluid.require("electron", require, "gpii.app.electron");
-
 require("./basic/dialog.js");
 
+var gpii = fluid.registerNamespace("gpii");
 
 /**
  * Component that represents the About dialog
@@ -34,7 +33,7 @@ fluid.defaults("gpii.app.aboutDialog", {
     config: {
         params: {
             userListeners: ["USB", "NFC", "Fingerprint", "Webcam & Voice"],
-            version: { expander: { func: "gpii.app.electron.app.getVersion" } }
+            version: "@expand:gpii.app.getVersion()"
         },
         fileSuffixPath: "aboutDialog/index.html"
     },
@@ -59,3 +58,13 @@ fluid.defaults("gpii.app.aboutDialog", {
         }
     }
 });
+
+
+/**
+ * Simple method for retrieving the gpii-app version. Currently it
+ * uses the Electron's api that makes use of the version in the `package.json`.
+ * @return {String} The version of the gpii-app
+ */
+gpii.app.getVersion = function () {
+    return require("electron").app.getVersion();
+};

--- a/src/main/userErrorsHandler.js
+++ b/src/main/userErrorsHandler.js
@@ -26,10 +26,7 @@ fluid.defaults("gpii.app.userErrorsHandler", {
     gradeNames: ["fluid.component"],
 
     messagePrefix: "gpii_userErrors",
-    messagesBundlePath : "%gpii-user-errors/bundles/gpii-userErrors-messageBundle_en.json5",
     errorProperties: ["title", "subhead", "details"],
-
-    errorMessages: "@expand:fluid.require({that}.options.messagesBundlePath)",
 
     invokers: {
         handleUserError: {
@@ -45,7 +42,7 @@ fluid.defaults("gpii.app.userErrorsHandler", {
         getErrorDetails: {
             funcName: "gpii.app.userErrorsHandler.getErrorDetails",
             args: [
-                "{that}.options.errorMessages",
+                "{messageBundles}.model.messages",
                 "{that}.options.messagePrefix",
                 "{that}.options.errorProperties",
                 "{arguments}.0"
@@ -60,17 +57,18 @@ fluid.defaults("gpii.app.userErrorsHandler", {
  * Currently there are three such properties - "title", "subhead", "details".
  * Every message key is expected to follow the format: <errorSupplierComponent>_<errorCode>-<errorProperty>,
  * e.g. GPII_userErrors_KeyInFail-title.
- * @param {Object} errorMessages - Object containing all messages for the different error codes
+ * @param {Object} messages - Object containing all messages.
  * @param {String} messagePrefix - The prefix for each error message key
  * @param {String[]} errorProperties - The properties of an error to be looked for
  * @param {String} errorCode - The code of the error that has occurred
  * @return {Object} {{title: String, subhead: String, details: String}}
  */
-gpii.app.userErrorsHandler.getErrorDetails = function (errorMessages, messagePrefix, errorProperties, errorCode) {
+gpii.app.userErrorsHandler.getErrorDetails = function (messages, messagePrefix, errorProperties, errorCode) {
+    var userErrorMessages = messages[messagePrefix];
     return errorProperties.reduce(function (errorDetails, errorProp) {
-        var propKey =  messagePrefix + "_" + errorCode + "-" + errorProp;
+        var errorPropKey =  errorCode + "-" + errorProp;
         // Extract error errorDetails from the bundle
-        errorDetails[errorProp] = errorMessages[propKey];
+        errorDetails[errorProp] = userErrorMessages[errorPropKey];
 
         return errorDetails;
     }, {});


### PR DESCRIPTION
Improve the "Mega bundle" grunt task in order to support gpii module relative paths.

This process is used for the "user errors" messages, so the `gpii-app` userErrors handler now make use of the mega bundle.