### PR TITLE
GPII-3247: Updated to Morphic branding

### DIFF
--- a/provisioning/Installer.ps1
+++ b/provisioning/Installer.ps1
@@ -14,8 +14,8 @@ $projectDir = (Get-Item $provisioningDir).parent.FullName
 
 Import-Module (Join-Path $provisioningDir 'Provisioning.psm1') -Force
 
-$installerRepo = "https://github.com/javihernandez/gpii-wix-installer"
-$installerBranch = "GPII-3247"
+$installerRepo = "https://github.com/GPII/gpii-wix-installer"
+$installerBranch = "HST"
 
 # Obtaining useful tools location.
 $installerDir = Join-Path $env:SystemDrive "installer" # a.k.a. C:\installer\

--- a/provisioning/Installer.ps1
+++ b/provisioning/Installer.ps1
@@ -14,8 +14,8 @@ $projectDir = (Get-Item $provisioningDir).parent.FullName
 
 Import-Module (Join-Path $provisioningDir 'Provisioning.psm1') -Force
 
-$installerRepo = "https://github.com/GPII/gpii-wix-installer"
-$installerBranch = "feds-audit"
+$installerRepo = "https://github.com/javihernandez/gpii-wix-installer"
+$installerBranch = "GPII-3247"
 
 # Obtaining useful tools location.
 $installerDir = Join-Path $env:SystemDrive "installer" # a.k.a. C:\installer\
@@ -92,17 +92,17 @@ Invoke-Command "robocopy" "$projectDir $preStagingDir package.json" $provisionin
 Invoke-Command "robocopy" "$projectDir $preStagingDir package-lock.json" $provisioningDir -errorLevel 3
 Invoke-Command "robocopy" "$projectDir $preStagingDir README.md" $provisioningDir -errorLevel 3
 
-$packagerMetadata = "--app-copyright=`"Raising the Floor - International Association`" --win32metadata.CompanyName=`"Raising the Floor - International Association`" --win32metadata.FileDescription=`"Morphic-App`" --win32metadata.OriginalFilename=`"gpii.exe`" --win32metadata.ProductName=`"Morphic-App`" --win32metadata.InternalName=`"Morphic-App`""
+$packagerMetadata = "--app-copyright=`"Raising the Floor - International Association`" --win32metadata.CompanyName=`"Raising the Floor - International Association`" --win32metadata.FileDescription=`"Morphic-App`" --win32metadata.OriginalFilename=`"morphic-app.exe`" --win32metadata.ProductName=`"Morphic-App`" --win32metadata.InternalName=`"Morphic-App`""
 
 $packagerDir = Join-Path $installerDir "packager"
 md $packagerDir
 # TODO: Delete --prune when got fixed this issue https://github.com/electron-userland/electron-packager/issues/495
 # Invoke-Command $npm "prune --production" $preStagingDir
-Invoke-Command "electron-packager.cmd" "$preStagingDir --platform=win32 --arch=ia32 --no-prune --overwrite --out=$packagerDir $packagerMetadata"
+Invoke-Command "electron-packager.cmd" "$preStagingDir morphic-app --platform=win32 --arch=ia32 --no-prune --overwrite --out=$packagerDir $packagerMetadata"
 
-# Copying the packaged GPII-App content to staging/.
+# Copying the packaged Morphic-app content to staging/.
 # TODO: Try to avoid using the electron-packager directory name hardcoding it.
-$packagedAppDir = (Join-Path $packagerDir "gpii-app-win32-ia32")
+$packagedAppDir = (Join-Path $packagerDir "morphic-app-win32-ia32")
 Copy-Item "$packagedAppDir\*" $stagingWindowsDir -Recurse
 
 md (Join-Path $installerDir "output")


### PR DESCRIPTION
Works with https://github.com/GPII/gpii-wix-installer/pull/42
Note that the reference to the installer on line 18 needs to be restored back after that PR gets merged. 