### PR TITLE
GPII-3409: Make sure "gpii.app" is attached with the local flow manager

### DIFF
--- a/tests/configs/gpii.tests.all.config.json
+++ b/tests/configs/gpii.tests.all.config.json
@@ -5,7 +5,7 @@
         "distributeOptions": {
             "distributeTaskTray": {
                 "record": "gpii.appWrapper",
-                "target": "{that flowManager}.options.gradeNames"
+                "target": "{that gpii.flowManager.local}.options.gradeNames"
             },
             "distributePcpChannelConnector": {
                 "record": {
@@ -20,7 +20,7 @@
                     "funcName": "gpii.tests.app.receiveApp",
                     "args": ["{testCaseHolder}", "{arguments}.0"]
                 },
-                "target": "{that flowManager gpii.app}.options.listeners.onCreate"
+                "target": "{that gpii.flowManager.local gpii.app}.options.listeners.onCreate"
             },
             "distributeDevPcpChannelConnector": {
                 "record": "gpii.app.dev.gpiiConnector",


### PR DESCRIPTION
When GPII runs in untrusted.all.local configs, regardless with dynamic device reporter or not, 2 flow managers will be started on your local machine:

1. The untrusted local flow manager
2. The cloud based flow manager

The former has the lifecycle manager module while the latter does not. So be specific to use {gpii.flowManager.local} at distributing "gpii.app" to make sure "gpii.app" is attached with the local flow manager. Using {flowManager} alone will distribute "gpii.app" to both.