### PR TITLE
NOJIRA: Fixed the error at a keyout.

### DIFF
--- a/tests/IntegrationTests.js
+++ b/tests/IntegrationTests.js
@@ -50,6 +50,10 @@ gpii.tests.app.startSequence = [
     { // Before the actual tests commence, the PSP application must be fully functional. The `onPSPReady` event guarantees that.
         event: "{that gpii.app}.events.onPSPReady",
         listener: "fluid.identity"
+    },
+    {
+        event: "{testEnvironment}.events.noUserLoggedIn",
+        listener: "fluid.identity"
     }
 ];
 
@@ -87,6 +91,9 @@ gpii.tests.app.testDefToServerEnvironment = function (testDef) {
                 tests: {
                     options: gpii.tests.app.testDefToCaseHolder(configurationName, testDef)
                 }
+            },
+            events: {
+                noUserLoggedIn: null
             }
         }
     };

--- a/tests/configs/gpii.tests.all.config.json
+++ b/tests/configs/gpii.tests.all.config.json
@@ -25,6 +25,12 @@
             "distributeDevPcpChannelConnector": {
                 "record": "gpii.app.dev.gpiiConnector",
                 "target": "{that gpiiConnector}.options.gradeNames"
+            },
+            "flowManager.escalate": {
+                "record": {
+                    "noUserLoggedIn.escalate": "{testEnvironment}.events.noUserLoggedIn"
+                },
+                "target": "{that localConfig flowManager}.options.listeners"
             }
         }
     },


### PR DESCRIPTION
The error at the "snapset_1a" keyout was caused by a race condition between:

1. the "snapset_1a" keyin;
2. the "noUser" keyin at the start of GPII.

Because #2 has not finished when the request for #1 was received, which ended up having both "noUser" and "snapset_1a" being keyed into GPII.

The fix is to wait until "noUser" keyin completes before starting the test sequence.