### PR TITLE
GPII-3429: Updated Chinese Traditional label on QSS

### DIFF
--- a/testData/qss/settings.json
+++ b/testData/qss/settings.json
@@ -17,7 +17,7 @@
                 "English",
                 "Հայերէն · Armenian",
                 "简体中文 · Chinese (Simplified)",
-                "繁体中文 · Chinese (Traditional - Simplified)",
+                "繁体中文 · Chinese (Traditional - Taiwan)",
                 "한국어 · Korean",
                 "Ру́сский · Russian",
                 "Español · Spanish"

--- a/testData/qss/settings.json
+++ b/testData/qss/settings.json
@@ -17,7 +17,7 @@
                 "English",
                 "Հայերէն · Armenian",
                 "简体中文 · Chinese (Simplified)",
-                "繁体中文 · Chinese (Traditional)",
+                "繁体中文 · Chinese (Traditional - Simplified)",
                 "한국어 · Korean",
                 "Ру́сский · Russian",
                 "Español · Spanish"


### PR DESCRIPTION
This one is coming from the feds-audit branch.

According to MS language packs reference, the language code to use for the traditional variant is zh-TW (Chinese Traditional - Taiwan).
See: https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/available-language-packs-for-windows