### PR TITLE
GPII-3446: Progress on including coverage report from 'main tests' run

### DIFF
--- a/src/main/dialogs/basic/dialog.js
+++ b/src/main/dialogs/basic/dialog.js
@@ -174,7 +174,8 @@ fluid.defaults("gpii.app.dialog", {
         },
         "onDestroy.cleanupElectron": {
             this: "{that}.dialog",
-            method: "destroy"
+            method: "destroy",
+            priority: "last"
         }
     },
     invokers: {

--- a/tests.js
+++ b/tests.js
@@ -7,6 +7,17 @@ var fs = require("graceful-fs");
 var path = require("path");
 var jqUnit = require("node-jqunit");
 
+var gpii = fluid.registerNamespace("gpii");
+
+fluid.require("%gpii-app/tests/lib/rendererCoverageServer");
+
+/*
+ * Start the coverage server
+ * XXX still recreated multiple times...
+ */
+var coverageServer = gpii.tests.app.rendererCoverageServer();
+
+
 // Code coverage harness, hooks into the jqUnit lifecycle and saves tests whenever the `onAllTestsDone` event is fired.
 // Must be hooked in before requiring any actual tests.
 jqUnit.onAllTestsDone.addListener(function () {
@@ -25,8 +36,9 @@ jqUnit.onAllTestsDone.addListener(function () {
     else {
         fluid.log("No code coverage data to save.");
     }
-});
 
+    coverageServer.destroy();
+});
 
 // Run the electron app tests with code coverage if possible.
 require("./tests/AppTests.js");

--- a/tests.js
+++ b/tests.js
@@ -27,6 +27,7 @@ jqUnit.onAllTestsDone.addListener(function () {
     }
 });
 
+
 // Run the electron app tests with code coverage if possible.
 require("./tests/AppTests.js");
 require("./tests/MessageBundlesTests.js");

--- a/tests/IntegrationTests.js
+++ b/tests/IntegrationTests.js
@@ -22,6 +22,7 @@ var fluid = require("gpii-universal"),
 
 require("gpii-windows/index.js");
 fluid.require("%gpii-universal/gpii/node_modules/testing");
+require("./lib/rendererCoverageCollector.js");
 
 gpii.loadTestingSupport();
 
@@ -59,7 +60,6 @@ gpii.tests.app.startSequence = [
     }
 ];
 
-
 /**
  * Attach instances that are needed in test cases.
  * @param {Component} testCaseHolder - The overall test cases holder
@@ -81,6 +81,11 @@ gpii.tests.app.testDefToCaseHolder = function (configurationName, testDefIn) {
     // as well as the server
     // sequence.unshift.apply(sequence, kettle.test.startServerSequence);
     sequence.unshift.apply(sequence, gpii.tests.app.startSequence);
+    sequence.push({
+        task: "gpii.tests.app.instrumentedDialog.requestCoverage",
+        resolve: "console.log",
+        resolveArgs: "COVERAGE!"
+    });
     testDef.modules = [{
         name: configurationName + " tests",
         tests: [{
@@ -103,6 +108,22 @@ gpii.tests.app.testDefToServerEnvironment = function (testDef) {
             components: {
                 tests: {
                     options: gpii.tests.app.testDefToCaseHolder(configurationName, testDef)
+                },
+                coverage: {
+                    type: "gpii.testem.coverage.express",
+                    options: {
+                        port: 7003,
+                        distributeOptions: {
+                            record: "%gpii-app/coverage",
+                            target: "{that gpii.testem.coverage.receiver.middleware}.options.coverageDir"
+                        },
+                        listeners: {
+                            "onCreate": { // XXX dev
+                                funcName: "console.log",
+                                args: ["ROUTER CREATED"]
+                            }
+                        }
+                    }
                 }
             },
             events: {

--- a/tests/IntegrationTests.js
+++ b/tests/IntegrationTests.js
@@ -108,22 +108,6 @@ gpii.tests.app.testDefToServerEnvironment = function (testDef) {
             components: {
                 tests: {
                     options: gpii.tests.app.testDefToCaseHolder(configurationName, testDef)
-                },
-                coverage: {
-                    type: "gpii.testem.coverage.express",
-                    options: {
-                        port: 7003,
-                        distributeOptions: {
-                            record: "%gpii-app/coverage",
-                            target: "{that gpii.testem.coverage.receiver.middleware}.options.coverageDir"
-                        },
-                        listeners: {
-                            "onCreate": { // XXX dev
-                                funcName: "console.log",
-                                args: ["ROUTER CREATED"]
-                            }
-                        }
-                    }
                 }
             },
             events: {

--- a/tests/QssTestDefs.js
+++ b/tests/QssTestDefs.js
@@ -77,6 +77,24 @@ gpii.tests.qss.testPspAndQssVisibility = function (app, params) {
     );
 };
 
+
+// for DEV purposes
+var _promise;
+gpii.tests.blockTestsElement = function () {
+    _promise = fluid.promise();
+    return _promise;
+};
+
+var electron = require("electron");
+// Restore tests running cycle
+electron.app.on("ready", function () {
+    electron.globalShortcut.register("Space", function () {
+        console.log("Go Go Go!");
+        _promise.resolve();
+    });
+});
+
+
 var qssCrossTestSequence = [
     /*
      * CROSS

--- a/tests/configs/gpii.tests.all.config.json5
+++ b/tests/configs/gpii.tests.all.config.json5
@@ -31,6 +31,10 @@
                     "noUserLoggedIn.escalate": "{testEnvironment}.events.noUserLoggedIn"
                 },
                 "target": "{that localConfig flowManager}.options.listeners"
+            },
+            "distribureInstrumentedDialog": {
+                "record": "gpii.tests.app.instrumentedDialog",
+                "target": "{that gpii.app.dialog}.options.gradeNames"
             }
         }
     },

--- a/tests/configs/gpii.tests.dev.config.json5
+++ b/tests/configs/gpii.tests.dev.config.json5
@@ -10,6 +10,6 @@
         }
     },
     "mergeConfigs": [
-        "./gpii.tests.all.config.json"
+        "./gpii.tests.all.config.json5"
     ]
 }

--- a/tests/configs/gpii.tests.production.config.json5
+++ b/tests/configs/gpii.tests.production.config.json5
@@ -1,6 +1,6 @@
 {
     "type": "gpii.tests.production.config",
     "mergeConfigs": [
-        "./gpii.tests.all.config.json"
+        "./gpii.tests.all.config.json5"
     ]
 }

--- a/tests/lib/rendererCoverageCollector.js
+++ b/tests/lib/rendererCoverageCollector.js
@@ -1,0 +1,136 @@
+/**
+ * Utilities for collection of renderer processes coverage
+ *
+ * prepending and appending necessary sequence elements to the test definitions and
+ * for bootstraping the test application instance.
+ * Copyright 2017 Raising the Floor - International
+ *
+ * Licensed under the New BSD license. You may not use this file except in
+ * compliance with this License.
+ * The research leading to these results has received funding from the European Union's
+ * Seventh Framework Programme (FP7/2007-2013) under grant agreement no. 289016.
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/universal/blob/master/LICENSE.txt
+ */
+
+
+var fluid = require("gpii-universal"),
+    gpii = fluid.registerNamespace("gpii");
+require("gpii-testem");
+
+
+function sendCoverage() {
+    var coveragePort = 7003; // TODO configurabale (stringTemplate)
+    // send coverage
+    // notify server for change
+
+    function notifyCoverageSuccess() {
+        require("electron").ipcRenderer.send("coverageSuccess");
+    }
+    // Similar to: https://github.com/GPII/gpii-testem/blob/master/src/js/client/coverageSender.js#L27
+    if (window.__coverage__) {
+        var xhr = new XMLHttpRequest();
+        xhr.onreadystatechange = function () {
+            if (this.readyState === 4) {
+                if (this.status === 200) {
+                    console.log("Saved coverage data.");
+                }
+                else {
+                    console.error("Error saving coverage data:", this.responseText);
+                }
+
+                // notify the main process TODO or listen for even of server
+                notifyCoverageSuccess();
+            }
+        };
+        xhr.open("POST", "http://localhost:" + coveragePort + "/coverage");
+        xhr.setRequestHeader("Content-type", "application/json");
+        var wrappedPayload = {
+            payload: {
+                document: {
+                    title: document.title,
+                    URL: document.URL
+                },
+                navigator: {
+                    appCodeName: navigator.appCodeName,
+                    appName: navigator.appName,
+                    product: navigator.product,
+                    productSub: navigator.productSub,
+                    userAgent: navigator.userAgent,
+                    vendor: navigator.vendor,
+                    vendorSub: navigator.vendorSub
+                },
+                coverage: window.__coverage__
+            }
+        };
+        xhr.send(JSON.stringify(wrappedPayload, null, 2));
+    } else {
+        // notify anyways
+        notifyCoverageSuccess();
+    }
+}
+
+
+
+/**
+ * Component that ensures `gpii.app.dialog`s are using the instrumented version of renderer content 
+ */
+fluid.defaults("gpii.tests.app.instrumentedDialog", {
+    // use the instrumented renderer files
+    config: {
+        filePrefixPath: "/instrumented/src/renderer"
+    },
+    listeners: {
+        // "onDestroy.cleanupElectron": null,
+        // "onCreate.attachCoverageCollector": {
+        //     funcName: "gpii.tests.app.instrumentedDialog.attachCoverageCollector",
+        //     args: ["{that}.dialog"]
+        // },
+        "onCreate.log": { // XXX dev
+            funcName: "console.log",
+            args: ["INSTRUMENTED DIALOG: ", "{that}.options.gradeNames"]
+        }
+    }
+});
+
+gpii.tests.app.instrumentedDialog.requestCoverage = function () {
+    var promise = fluid.promise();
+
+    var dialogs = require("electron").BrowserWindow.getAllWindows();
+    var dialogCounter = 0;
+
+    fluid.each(dialogs, function (dialog) {
+        // dialog.webContents.toggleDevTools();
+        console.log("REQUEST COVERAGE: ", dialog.gradeNames);
+        gpii.test.executeJavaScript(dialog, sendCoverage.toString() + " sendCoverage();");
+    });
+
+    require("electron").ipcMain.on("coverageSuccess", function (e) {
+        dialogCounter++;
+
+        var diags = require("electron").BrowserWindow.getAllWindows();
+        console.log("State: ", diags.map((d) => d.isDestroyed()))
+        console.log("Sender: ", e.sender.isDestroyed());
+
+        // XXX DEV
+        console.log("Getting: ", dialogs.length, diags.length, dialogCounter);
+
+        if (dialogCounter >= dialogs.length) {
+            promise.resolve();
+            require("electron").ipcMain.removeAllListeners("coverageSuccess");
+        }
+    });
+
+    return promise;
+};
+
+gpii.tests.app.instrumentedDialog.attachCoverageCollector = function (dialog) {
+    dialog.on("closed", function () {
+        // TODO load script form file
+        // XXX DEV
+        console.log("REQUEST COVERAGE: ", dialog.gradeNames);
+        gpii.test.executeJavaScript(dialog, sendCoverage.toString() + " sendCoverage();");
+    });
+    require("electron").ipcMain.on("covereageSuccess", dialog.destroy);
+};
+


### PR DESCRIPTION
This introduces coverage data for renderer processes generated from the
execution of the "main process" integration tests as we have integration tests that communicate with the BrowserWindows. In other words this
registers end-to-end tests coverage.